### PR TITLE
New function to detect export_type & changes to ask_for csv()

### DIFF
--- a/R/loading_files.R
+++ b/R/loading_files.R
@@ -76,28 +76,65 @@ ask_for_qsf <- function(surveyfile) {
 #' @param headerrows the number of rows before responses begin in the CSV data
 #' @return a list of two elements: the responses data frame, and the original_first_rows data frame
 ask_for_csv <- function(responsesfile, headerrows) {
-    if (missing(responsesfile)) {
-        cat("Select CSV Response File:")
-        responsesfile = file.choose()
-    }
-    if (missing(headerrows)) {
-      headerrows <- 3
-    }
-    responses = read.csv(responsesfile, check.names = FALSE, stringsAsFactors = FALSE)
-    responses[which(colnames(responses) == "")] <- NULL
-    original_first_rows <- responses[1:(headerrows-1),]
+  if (missing(responsesfile)) {
+    cat("Select CSV Response File:")
+    responsesfile = file.choose()
+  }
+  responses = read.csv(responsesfile, check.names = FALSE, stringsAsFactors = FALSE)
+  responses[which(colnames(responses) == "")] <- NULL
+  organised_responses <- manage_export_type(responses)
+  export_type<- organised_responses[[1]]
+  original_first_rows<- organised_responses[[2]]
+  responses <- organised_responses[[3]]
+  return(list(responses, original_first_rows, export_type))
+}
 
-    if (headerrows == 3) {
-      original_first_rows[2,] <- lapply(original_first_rows[2, ], function(x) {
-        x <- gsub("^\\{'ImportId': '", "", x, perl=TRUE)
-        x <- gsub("'\\}$", "", x, perl=TRUE)
+#' Manages the different export formats\
+#'
+#' Based on the selection for the three different formats: data table(dt, legacy unchecked legacy(lul)
+#' legacy checked legacy(lcl), we clean QIDs and rearrange columns where neccesay, and split the
+#' response data into two table: responses and original first rows.
+#' The function also returns the exfort format type.
+#'
+manage_export_type<- function(responses){
+  # first we deal with legacy unchecked legacy and data table
+  if ('ResponseId' %in% names(responses) |'ResponseID' %in% names(responses)){
+    # if data table
+    if ('ResponseId' %in% names(responses)){
+      response_type <- 'dt'
+      # rearrange the table to have ResponseId at start
+      responses<- dplyr::select(responses, 'ResponseId', everything())%>%
+        rename('ResponseID'='ResponseId')
+      # clean the QIDs
+      responses[2,] <- lapply(responses[2, ], function(x) {
+        x <- stringr::str_replace_all(x, "\\{\"ImportId\":\"", "" )
+        x <- stringr::str_replace_all(x, "\",\"choiceId\":\"", "-" )
+        x <- stringr::str_replace_all(x, "\"\\}", "" )
+        x <- stringr::str_replace_all(x, "_", "-" )
       })
     }
-
-    responses <- responses[headerrows:nrow(responses),]
-    responses <- responses[apply(responses, 1, function(x) any(x != "")),]
-    responses <- as.data.frame(apply(responses, 2, trimws),stringsAsFactors = FALSE)
-    return(list(responses, original_first_rows))
+    # if not data table, it's legacy unchecked legacy
+    else{
+      response_type <- 'lul'
+      # clean the QIDs
+      responses[2,] <- lapply(responses[2, ], function(x) {
+        x <- stringr::str_replace_all(x, "^\\{'ImportId': '", "" )
+        x <- stringr::str_replace_all(x, "'\\}$", "" )
+      })
+    }
+    # split by responses and original_first_rows
+    original_first_rows <- dplyr::filter(responses, ! stringr::str_detect(ResponseID, "^R_"))
+    responses<- dplyr::filter(responses, stringr::str_detect(ResponseID, "^R_"))
+  }
+  # if legacy checked legacy
+  else{
+    response_type <- 'lcl'
+    original_first_rows<- responses[1:1,]
+    responses <- responses[2:nrow(responses),]
+  }
+  responses <- responses[apply(responses, 1, function(x) any(x != "")),]
+  responses <- as.data.frame(apply(responses, 2, trimws),stringsAsFactors = FALSE)
+  return(list(response_type, original_first_rows, responses))
 }
 
 


### PR DESCRIPTION
ask for csv() is reorganised. It now returns an extra variable called export_type which is one of lcl, lul or dt. ask_for_csv() now passes the responses read from the csv to manage_export_type() which selects for one of the export formats and does the required processing.